### PR TITLE
Add support for reading modem/line status flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,44 @@ var bitmodes = {
  */
 ```
 
+## Modem / Line status flags
+
+To manually get the modem and line status values:
+
+```nodejs
+device.modemStatus(function(err, status) {
+  console.log(status);
+}); 
+```
+
+Or, to be notified anytime the change on an openned device:
+
+```nodejs
+device.on('modemStatus', function(status) { 
+  console.log(status)
+});
+``` 
+
+An example of the status object returned:
+
+```js
+{
+  raw: 176,   // the raw value received from the FTDI library
+
+  // Modem status
+  cts: true,  // Clear To Send
+  dsr: true,  // Data Set Ready
+  ri:  false, // Ring Indicator
+  dcd: true,  // Data Carrier Detect
+
+  // Line status
+  oe:  false, // Overrun Error
+  pe:  false, // Parity Error
+  fe:  false, // Framing Error
+  bi:  false  // Break Interrupt
+}
+```
+
 # Troubleshoot
 
 ### Windows

--- a/index.js
+++ b/index.js
@@ -75,6 +75,8 @@ FtdiDevice.prototype.open = function(settings, callback) {
       self.emit('open');
     }
     if (callback) { callback(err); }
+  }, function(err, modemStatus) {
+    self.emit('modemStatus', modemStatus);
   });
 };
 
@@ -119,6 +121,20 @@ FtdiDevice.prototype.close = function(callback) {
     }
     self.removeAllListeners();
     if (callback) callback(err);
+  });
+};
+
+/**
+ * Get the modem & line status flags
+ * @param  {Function} callback The function, that will be called when the flags have been retreived.
+ *                             `function(err, flags){}`
+ */
+FtdiDevice.prototype.modemStatus = function(callback) {
+  this.FTDIDevice.modemStatus(function(err, status) {
+    if (err) {
+      self.emit('error', err);
+    } 
+    if (callback) callback(err, status);
   });
 };
 

--- a/src/ftdi_constants.h
+++ b/src/ftdi_constants.h
@@ -43,6 +43,16 @@
 #define FT_STATUS_CUSTOM_ALREADY_OPEN				"Device Already open"
 #define FT_STATUS_CUSTOM_ALREADY_CLOSING			"Device Already closing"
 
+#define FT_MODEM_CTS 0x10
+#define FT_MODEM_DSR 0x20
+#define FT_MODEM_RI  0x40
+#define FT_MODEM_DCD 0x80
+
+#define FT_LINE_OE 0x02
+#define FT_LINE_PE 0x04
+#define FT_LINE_FE 0x08
+#define FT_LINE_BI 0x10
+
 // Lock for Library Calls
 extern uv_mutex_t libraryMutex;
 extern uv_mutex_t vidPidMutex;

--- a/src/ftdi_device.h
+++ b/src/ftdi_device.h
@@ -26,6 +26,11 @@ typedef struct
   DWORD length;
 } WriteBaton_t;
 
+typedef struct
+{
+  DWORD status;
+} ModemBaton_t;
+
 typedef enum
 {
   ConnectType_ByIndex,
@@ -78,11 +83,13 @@ class FtdiDevice : public Nan::ObjectWrap
     static NAN_METHOD(New);
     static NAN_METHOD(Open);
     static NAN_METHOD(Write);
+    static NAN_METHOD(ModemStatus);
     static NAN_METHOD(Close);
 
-    static FT_STATUS OpenAsync(FtdiDevice* device, Nan::Callback *callback_read);
+    static FT_STATUS OpenAsync(FtdiDevice* device, Nan::Callback *callback_read, Nan::Callback *callback_modem);
     static FT_STATUS ReadDataAsync(FtdiDevice* device, ReadBaton_t* baton);
     static FT_STATUS WriteAsync(FtdiDevice* device, WriteBaton_t* baton);
+    static FT_STATUS ModemStatusAsync(FtdiDevice* device, ModemBaton_t* baton);
     static FT_STATUS CloseAsync(FtdiDevice* device);
 
     void ExtractDeviceSettings(Local<v8::Object> options);


### PR DESCRIPTION
This PR adds bindings to the `FT_GetModemStatus` method as well as creates an event emitter that fires ever time any of the modem/line status values change.

I'm planning to use this in order to use the "input" serial wires -- like `DCD` -- as simple input indicators along-side serial communication.

# Usage:

```js
var device = new ftdi.FtdiDevice(0);
device.open({
  baudrate: 9600,
  databits: 8,
  stopbits: 1,
  parity: 'none'
}, (err) => {
  device.on('modemStatus', function (status) { 
    console.log(status);
  });
});
```