### PR TITLE
Fix include for gettimeofday()

### DIFF
--- a/src/ftdi_device.cc
+++ b/src/ftdi_device.cc
@@ -13,7 +13,7 @@
 
 #ifndef WIN32
     #include <unistd.h>
-    #include <time.h>
+    #include <sys/time.h>
 #else
     #include <windows.h>
 #endif


### PR DESCRIPTION
I got a build error and found that the header file to use for `gettimeofday()` is `sys/time.h`, not `time.h`. To be honest I'm not sure how this could have ever worked before but I'm not a C expert either. 

Anyway, this fixed the build error for me and the module is working fine.