### PR TITLE
Bump version to 1.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ Try to unload the Apple FTDI Driver by running the following command:
 
 # Release Notes
 
+## v1.2.2
+
+- Fix wrong time.h header
+
 ## v1.2.0
 
 - Add support for node v4, v5

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ftdi",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "FTDI bindings for Node.js",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
The node-ftdi version 1.2.1 cannot be used with Debian 9 when installed using npm (#28). The fix has been already merged (#26), but a new version needs to be published to npm.