### PR TITLE
Fixed a problem that segmentation fault occurs when ReadWorker baton is overwitten.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ftdi",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "FTDI bindings for Node.js",
   "main": "index.js",
   "dependencies": {
@@ -22,9 +22,9 @@
     "driver",
     "device"
   ],
-  "homepage": "https://github.com/thomaschaaf/node-ftdi",
+  "homepage": "https://github.com/toyoge009/node-ftdi",
   "bugs": {
-    "url": "https://github.com/thomaschaaf/node-ftdi/issues"
+    "url": "https://github.com/toyoge009/node-ftdi/issues"
   },
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
     "driver",
     "device"
   ],
-  "homepage": "https://github.com/toyoge009/node-ftdi",
+  "homepage": "https://github.com/thomaschaaf/node-ftdi",
   "bugs": {
-    "url": "https://github.com/toyoge009/node-ftdi/issues"
+    "url": "https://github.com/thomaschaaf/node-ftdi/issues"
   },
   "license": "MIT"
 }

--- a/src/ftdi_device.cc
+++ b/src/ftdi_device.cc
@@ -160,7 +160,9 @@ class ReadWorker : public Nan::AsyncWorker {
   // here, so everything we need for input and output
   // should go on `this`.
   void Execute () {
-    baton = new ReadBaton_t();
+    baton = &batonEntity;
+    baton->length = 0;
+    baton->data = NULL;
     status = FtdiDevice::ReadDataAsync(device, baton);
   }
 
@@ -203,7 +205,7 @@ class ReadWorker : public Nan::AsyncWorker {
       callback->Call(2, argv);
     }
 
-    if(baton->length != 0)
+    if(baton->data != NULL)
     {
       delete baton->data;
       baton->length = 0;
@@ -221,13 +223,13 @@ class ReadWorker : public Nan::AsyncWorker {
       AsyncQueueWorkerPersistent(this);
     }
 
-    delete baton;
   };
 
  private:
   FT_STATUS status;
   FtdiDevice* device;
   ReadBaton_t* baton;
+  ReadBaton_t batonEntity;
 };
 
 FT_STATUS FtdiDevice::ReadDataAsync(FtdiDevice* device, ReadBaton_t* baton)


### PR DESCRIPTION
I fixed the problem that a segmentation fault occurs when the readWorker baton is overwritten.
In the HandleOKCallback function, the Execute function is called and "baton = new ReadBaton_t ();" overwrites baton by calling the AsyncQueueWorkerPersistent function and then executing "delete baton". I stopped getting baton's memory dynamically. This will not cause memory corruption.